### PR TITLE
Escape double quotes in docstring to avoid injections

### DIFF
--- a/selfdocumenter.py
+++ b/selfdocumenter.py
@@ -34,6 +34,7 @@ def document(docstring):
     index = source_code.index(caller_function_definition) + 1
 
     # See if docstring already exists and fail the function if it does
+    docstring = docstring.replace('"', r'\"')
     docstring_pattern = r'^\s*"""' + docstring + '"""\s*$'
     if re.match(docstring_pattern, source_code[index]):
         return False
@@ -47,3 +48,4 @@ def document(docstring):
 
     with open(caller_filename, 'w') as source_file:
         source_file.write('\n'.join(source_code))
+

--- a/selfdocumenter.py
+++ b/selfdocumenter.py
@@ -35,7 +35,7 @@ def document(docstring):
 
     # See if docstring already exists and fail the function if it does
     docstring_pattern = r'^\s*"""' + docstring + '"""\s*$'
-    if re.match(docstring_pattern,source_code[index]):
+    if re.match(docstring_pattern, source_code[index]):
         return False
 
     # Add docstring to correct position with indentation


### PR DESCRIPTION
A bug was found by a participant in PyCon Sweden that allowed
arbitrary code execution to be injected into the original source code
if the docstring had triple-double quotes (""") as that would end
the injected docstring, allowing any code to be run.

This commit fixes that loophole.